### PR TITLE
Capture function calls in app and send chat history to eval framework

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -80,7 +80,7 @@ async def handle_realtime_messages(websocket: WebSocket, client: RealtimeClientB
             )
         )
 
-    idx_last_sent = len(chat_history.messages)  # Chat history will contain system prompt
+    idx_first_msg_to_send = len(chat_history.messages)  # Chat history will contain system prompt
     async for event in client.receive(audio_output_callback=from_realtime_to_acs):
         match event.service_type:
             case ListenEvents.SESSION_CREATED:
@@ -115,11 +115,11 @@ async def handle_realtime_messages(websocket: WebSocket, client: RealtimeClientB
                     json.dumps(
                         {
                             "kind": "ChatHistory",
-                            "data": export_chat_history(chat_history, from_index=idx_last_sent + 1)
+                            "data": export_chat_history(chat_history, from_index=idx_first_msg_to_send)
                         }
                     )
                 )
-                idx_last_sent = len(chat_history.messages)
+                idx_first_msg_to_send = len(chat_history.messages)
             case ListenEvents.RESPONSE_AUDIO_TRANSCRIPT_DONE:
                 logger.info(f" AI:-- {event.service_event.transcript}")  # type: ignore
                 # Add assistant message to chat history

--- a/api/app/plugins/delivery.py
+++ b/api/app/plugins/delivery.py
@@ -21,4 +21,4 @@ class DeliveryPlugin:
             str: A message indicating the availability of delivery slots.
         """
         logger.info(f"@ get_available_slots_for_delivery called for {date}")
-        return "All slots are taken for Wednesday, rest of days are available."
+        return "All slots are taken for Wednesday, all other days are free to take."

--- a/api/app/sk_utils.py
+++ b/api/app/sk_utils.py
@@ -1,0 +1,50 @@
+import json
+from semantic_kernel.contents import ChatHistory
+from semantic_kernel.contents import FunctionCallContent, FunctionResultContent
+
+
+def export_chat_history(chat_history: ChatHistory, from_index: int = 0) -> str:
+    """Convert chat history to JSON format.
+
+    Args:
+        chat_history: the ChatHistory object to export
+        from_index: starting index to export from (default: 0, export all messages)
+
+    Returns:
+        A JSON string representation of the chat history
+    """
+    # Filter messages from the given index
+    messages_raw = chat_history.messages[from_index:]
+
+    # Convert messages from SK class to dict
+    messages_formatted = []
+    for msg in messages_raw:
+        message_data = {
+            "role": msg.role.value,
+            "content": msg.content or "",
+        }
+
+        # Include function calls if present
+        function_calls = []
+        for item in msg.items:
+            if isinstance(item, FunctionCallContent):
+                function_calls.append({
+                    "name": item.function_name,
+                    "plugin": item.plugin_name,
+                    "arguments": json.loads(item.arguments)
+                })
+            elif isinstance(item, FunctionResultContent):
+                function_calls.append({
+                    "name": item.function_name,
+                    "plugin": item.plugin_name,
+                    "arguments_sent": item.metadata["arguments"],
+                    "arguments_used": item.metadata["used_arguments"],
+                    "result": item.result
+                })
+
+        if function_calls:
+            message_data["function_calls"] = function_calls
+
+        messages_formatted.append(message_data)
+
+    return messages_formatted

--- a/api/app/sk_utils.py
+++ b/api/app/sk_utils.py
@@ -20,9 +20,11 @@ def export_chat_history(chat_history: ChatHistory, from_index: int = 0) -> str:
     messages_formatted = []
     for msg in messages_raw:
         message_data = {
-            "role": msg.role.value,
-            "content": msg.content or "",
+            "role": msg.role.value
         }
+
+        if msg.content:
+            message_data["content"] = str(msg.content)
 
         # Include function calls if present
         function_calls = []


### PR DESCRIPTION
- Capture events to fill in chat history:
  - Response transcript as assistant message
  - Function call results (also contain name & arguments)
  - Function calls are also available but seem redundant if we have results. Disabled for now but didn't remove just in case.
  - I wanted to add user messages as well but input audio transcript is not working, so sth to potentially do in the future.
 - Export new entries of chat history and send over websocket every time a response is created (seemed the easiest way to pass them for now)
 - Eval framework receives this new `"ChatHistory"` type of data as well and stores it to do metric calculation later on